### PR TITLE
Removing constructor compilation warnings

### DIFF
--- a/contracts/tokens/NFToken.sol
+++ b/contracts/tokens/NFToken.sol
@@ -118,7 +118,6 @@ contract NFToken is Ownable, ERC721, SupportsInterface {
    * @dev Contract constructor.
    */
   constructor()
-    SupportsInterface()
     public
   {
     supportedInterfaces[0x80ac58cd] = true; // ERC721

--- a/contracts/tokens/NFTokenEnumerable.sol
+++ b/contracts/tokens/NFTokenEnumerable.sol
@@ -32,7 +32,6 @@ contract NFTokenEnumerable is NFToken, ERC721Enumerable {
    * @dev Contract constructor.
    */
   constructor()
-    NFToken()
     public
   {
     supportedInterfaces[0x780e9d63] = true; // ERC721Enumerable

--- a/contracts/tokens/NFTokenMetadata.sol
+++ b/contracts/tokens/NFTokenMetadata.sol
@@ -32,7 +32,6 @@ contract NFTokenMetadata is NFToken, ERC721Metadata {
     string _name,
     string _symbol
   )
-    NFToken()
     public
   {
     nftName = _name;


### PR DESCRIPTION
Truffle throws compilation warnings when constructors with no parameters are called on child contracts. It seems that this calls are unnecessary. All tests pass.

Ref: https://github.com/0xcert/ethereum-erc721/issues/37