### PR TITLE
Simplify reassigning

### DIFF
--- a/contracts/tokens/NFToken.sol
+++ b/contracts/tokens/NFToken.sol
@@ -252,7 +252,6 @@ contract NFToken is
   {
     address tokenOwner = idToOwner[_tokenId];
     require(_approved != tokenOwner);
-    require(!(getApproved(_tokenId) == address(0) && _approved == address(0)));
 
     idToApprovals[_tokenId] = _approved;
     emit Approval(tokenOwner, _approved, _tokenId);


### PR DESCRIPTION
Don't require owner to first clear any prior assignments.