### PR TITLE
add ownable to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,12 @@ The easiest way to start is to create a new file under `contracts/tokens/` (e.g.
 pragma solidity ^0.4.23;
 
 import "../tokens/NFTokenMetadata.sol";
+import "@0xcert/ethereum-utils/contracts/ownership/Ownable.sol";
 
-contract MyNFToken is NFTokenMetadata {
+contract MyNFToken is
+  NFTokenMetadata,
+  Ownable
+{
 
   constructor(
     string _name,


### PR DESCRIPTION
The code in the readme fails to compile, as Ownable has not been imported. This fix imports and inherits Ownable. Alternatively, usage of onlyOwner could be removed. 
resolves #103 