### PR TITLE
Gas cost optimization in calculating index size and in usage of safeMath. 

### DIFF
--- a/contracts/tokens/NFToken.sol
+++ b/contracts/tokens/NFToken.sol
@@ -429,7 +429,7 @@ contract NFToken is
   {
     require(idToOwner[_tokenId] == _from);
     assert(ownerToNFTokenCount[_from] > 0);
-    ownerToNFTokenCount[_from] = ownerToNFTokenCount[_from].sub(1);
+    ownerToNFTokenCount[_from] = ownerToNFTokenCount[_from] - 1;
     delete idToOwner[_tokenId];
   }
 

--- a/contracts/tokens/NFTokenEnumerable.sol
+++ b/contracts/tokens/NFTokenEnumerable.sol
@@ -79,7 +79,7 @@ contract NFTokenEnumerable is
     uint256 tokenIndex = idToIndex[_tokenId];
     // Sanity check. This could be removed in the future.
     assert(tokens[tokenIndex] == _tokenId);
-    uint256 lastTokenIndex = tokens.length.sub(1);
+    uint256 lastTokenIndex = tokens.length - 1;
     uint256 lastToken = tokens[lastTokenIndex];
 
     tokens[tokenIndex] = lastToken;
@@ -106,7 +106,7 @@ contract NFTokenEnumerable is
     assert(ownerToIds[_from].length > 0);
 
     uint256 tokenToRemoveIndex = idToOwnerIndex[_tokenId];
-    uint256 lastTokenIndex = ownerToIds[_from].length.sub(1);
+    uint256 lastTokenIndex = ownerToIds[_from].length - 1;
     uint256 lastToken = ownerToIds[_from][lastTokenIndex];
 
     ownerToIds[_from][tokenToRemoveIndex] = lastToken;

--- a/contracts/tokens/NFTokenEnumerable.sol
+++ b/contracts/tokens/NFTokenEnumerable.sol
@@ -55,8 +55,8 @@ contract NFTokenEnumerable is
     internal
   {
     super._mint(_to, _tokenId);
-    tokens.push(_tokenId);
-    idToIndex[_tokenId] = tokens.length.sub(1);
+    uint256 length = tokens.push(_tokenId);
+    idToIndex[_tokenId] = length - 1;
   }
 
   /**

--- a/contracts/tokens/NFTokenEnumerable.sol
+++ b/contracts/tokens/NFTokenEnumerable.sol
@@ -131,9 +131,8 @@ contract NFTokenEnumerable is
   {
     super.addNFToken(_to, _tokenId);
 
-    uint256 length = ownerToIds[_to].length;
-    ownerToIds[_to].push(_tokenId);
-    idToOwnerIndex[_tokenId] = length;
+    uint256 length = ownerToIds[_to].push(_tokenId);
+    idToOwnerIndex[_tokenId] = length - 1;
   }
 
   /**


### PR DESCRIPTION
I removed using safeMath where there are first checks like `length > 0` then subtraction of -1 since it is unnecessary and uses gas. 