### PR TITLE
Stop using "claim" word

### DIFF
--- a/test/tokens/NFToken.test.js
+++ b/test/tokens/NFToken.test.js
@@ -27,12 +27,12 @@ contract('NFTokenMock', (accounts) => {
     assert.equal(count.toNumber(), 1);
   });
 
-  it('throws when trying to mint 2 NFTs with the same claim', async () => {
+  it('throws when trying to mint 2 NFTs with the same ID', async () => {
     await nftoken.mint(accounts[0], id2);
     await assertRevert(nftoken.mint(accounts[0], id2));
   });
 
-  it('throws trying to mint NFT with empty claim', async () => {
+  it('throws trying to mint NFT with empty ID', async () => {
     await assertRevert(nftoken.mint(accounts[0], ''));
   });
 


### PR DESCRIPTION
Previously, we thought the tokens would be indexed to claims (I think). This is why the IDs were called claims.

But we're not going to do that. So just call the claims IDs.