### PR TITLE
Rename as "reference implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Build Status](https://travis-ci.org/0xcert/ethereum-erc721.svg?branch=master)&nbsp;[![NPM Version](https://badge.fury.io/js/@0xcert%2Fethereum-erc721.svg)](https://www.npmjs.com/package/@0xcert/ethereum-erc721)&nbsp;[![Dependencies Status](https://david-dm.org/0xcert/ethereum-erc721.svg)](https://david-dm.org/0xcert/ethereum-erc721)&nbsp;[![Bug Bounty](https://img.shields.io/badge/bounty-closed-2930e8.svg)](https://github.com/0xcert/ethereum-erc721/issues/46)
 
-# ERC-721 Token
+# ERC-721 Token — Reference Implementation
 
 This is the complete reference implementation of the [ERC-721](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md) non-fungible token standard for the Ethereum blockchain. This is an open source project built with [Truffle](http://truffleframework.com) framework.
 


### PR DESCRIPTION
This is a stronger statement and I believe it is warranted given our prominent placement in the ERC-721 standard.