### PR TITLE
Do not require exact compiler version

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ You have created and have possession of unique glass-blown artwork (each having 
 To do this, simply paste the code belowe into Remix and deploy the smart contract. You will "mint" a token for each new piece of artwork you want to see. Then you will "burn" that token when you surrender physical possession of the piece.
 
 ```solidity
-pragma solidity 0.5.1;
+pragma solidity ^0.5.1;
 
 import "https://github.com/0xcert/ethereum-erc721/src/contracts/tokens/nf-token-metadata.sol";
 import "https://github.com/0xcert/ethereum-erc721/src/contracts/ownership/ownable.sol";

--- a/src/contracts/math/safe-math.sol
+++ b/src/contracts/math/safe-math.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.1;
+pragma solidity ^0.5.1;
 
 /**
  * @dev Math operations with safety checks that throw on error. This contract is based on the 

--- a/src/contracts/mocks/nf-token-enumerable-mock.sol
+++ b/src/contracts/mocks/nf-token-enumerable-mock.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.1;
+pragma solidity ^0.5.1;
 
 import "../../contracts/tokens/nf-token-enumerable.sol";
 import "../ownership/ownable.sol";

--- a/src/contracts/mocks/nf-token-metadata-enumerable-mock.sol
+++ b/src/contracts/mocks/nf-token-metadata-enumerable-mock.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.1;
+pragma solidity ^0.5.1;
 
 import "../tokens/nf-token-metadata.sol";
 import "../tokens/nf-token-enumerable.sol";

--- a/src/contracts/mocks/nf-token-metadata-mock.sol
+++ b/src/contracts/mocks/nf-token-metadata-mock.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.1;
+pragma solidity ^0.5.1;
 
 import "../tokens/nf-token-metadata.sol";
 import "../ownership/ownable.sol";

--- a/src/contracts/mocks/nf-token-mock.sol
+++ b/src/contracts/mocks/nf-token-mock.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.1;
+pragma solidity ^0.5.1;
 
 import "../../contracts/tokens/nf-token.sol";
 import "../ownership/ownable.sol";

--- a/src/contracts/ownership/ownable.sol
+++ b/src/contracts/ownership/ownable.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.1;
+pragma solidity ^0.5.1;
 
 /**
  * @dev The contract has an owner address, and provides basic authorization control whitch

--- a/src/contracts/tokens/erc721-enumerable.sol
+++ b/src/contracts/tokens/erc721-enumerable.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.1;
+pragma solidity ^0.5.1;
 
 /**
  * @dev Optional enumeration extension for ERC-721 non-fungible token standard.

--- a/src/contracts/tokens/erc721-metadata.sol
+++ b/src/contracts/tokens/erc721-metadata.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.1;
+pragma solidity ^0.5.1;
 
 /**
  * @dev Optional metadata extension for ERC-721 non-fungible token standard.

--- a/src/contracts/tokens/erc721-token-receiver.sol
+++ b/src/contracts/tokens/erc721-token-receiver.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.1;
+pragma solidity ^0.5.1;
 
 /**
  * @dev ERC-721 interface for accepting safe transfers. 

--- a/src/contracts/tokens/erc721.sol
+++ b/src/contracts/tokens/erc721.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.1;
+pragma solidity ^0.5.1;
 
 /**
  * @dev ERC-721 non-fungible token standard. 

--- a/src/contracts/tokens/nf-token-enumerable.sol
+++ b/src/contracts/tokens/nf-token-enumerable.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.1;
+pragma solidity ^0.5.1;
 
 import "./nf-token.sol";
 import "./erc721-enumerable.sol";

--- a/src/contracts/tokens/nf-token-metadata.sol
+++ b/src/contracts/tokens/nf-token-metadata.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.1;
+pragma solidity ^0.5.1;
 
 import "./nf-token.sol";
 import "./erc721-metadata.sol";

--- a/src/contracts/tokens/nf-token.sol
+++ b/src/contracts/tokens/nf-token.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.1;
+pragma solidity ^0.5.1;
 
 import "./erc721.sol";
 import "./erc721-token-receiver.sol";

--- a/src/contracts/utils/address-utils.sol
+++ b/src/contracts/utils/address-utils.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.1;
+pragma solidity ^0.5.1;
 
 /**
  * @dev Utility library of inline functions on addresses.

--- a/src/contracts/utils/erc165.sol
+++ b/src/contracts/utils/erc165.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.1;
+pragma solidity ^0.5.1;
 
 /**
  * @dev A standard for detecting smart contract interfaces. 

--- a/src/contracts/utils/supports-interface.sol
+++ b/src/contracts/utils/supports-interface.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.1;
+pragma solidity ^0.5.1;
 
 import "./erc165.sol";
 

--- a/src/tests/mocks/nf-token-enumerable-test-mock.sol
+++ b/src/tests/mocks/nf-token-enumerable-test-mock.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.1;
+pragma solidity ^0.5.1;
 
 import "../../contracts/mocks/nf-token-enumerable-mock.sol";
 

--- a/src/tests/mocks/nf-token-metadata-test-mock.sol
+++ b/src/tests/mocks/nf-token-metadata-test-mock.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.1;
+pragma solidity ^0.5.1;
 
 import "../../contracts/mocks/nf-token-metadata-mock.sol";
 

--- a/src/tests/mocks/nf-token-receiver-test-mock.sol
+++ b/src/tests/mocks/nf-token-receiver-test-mock.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.1;
+pragma solidity ^0.5.1;
 
 import "../../contracts/tokens/erc721-token-receiver.sol";
 


### PR DESCRIPTION
Presently, the current version of Solidity is disallowed by the code. This PR allows the current version.