### PR TITLE
Update comments in nf-token-enumerable.sol

### DIFF
--- a/src/contracts/tokens/nf-token-enumerable.sol
+++ b/src/contracts/tokens/nf-token-enumerable.sol
@@ -17,7 +17,7 @@ contract NFTokenEnumerable is
   uint256[] internal tokens;
 
   /**
-   * @dev Mapping from token ID its index in global tokens array.
+   * @dev Mapping from token ID to its index in global tokens array.
    */
   mapping(uint256 => uint256) internal idToIndex;
 


### PR DESCRIPTION
corrected the comment at line 20 that describes what idToIndex mapping is all about.